### PR TITLE
False mention of PhishTank in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The configuration variables at the top of the script determine:
 * Nagios "critical" threshold (threshold_critical)
 * Nagios "warning" threshold (threshold_warn)
 
-The Phishtank API key can be obtained for free at: https://www.virustotal.com/#/join-us.
+The VirusTotal API key can be obtained for free at: https://www.virustotal.com/#/join-us.
 
 
 Usage


### PR DESCRIPTION
This is for sure a copy/paste error, but it could be misleading.